### PR TITLE
FEAT: Data Caching

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    logging: {
+        fetches: {
+            fullUrl: true,
+        }
+    }
+};
 
 export default nextConfig;

--- a/src/app/(searchable)/page.tsx
+++ b/src/app/(searchable)/page.tsx
@@ -1,18 +1,53 @@
 import MovieItems from "@/components/movie-item";
 import style from "./page.module.css";
 import movies from '@/mock/mock.json';
+import { MovieData } from "@/types";
+
+
+async function AllMovies() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`,
+      // 업데이트가 필요하지 않기 때문에 cache에 저장
+      { cache: "force-cache" }
+  );
+  if(!res.ok) {
+      return <div>요청에 실패하였습니다</div>
+  }
+  const allMovies: MovieData[] = await res.json();
+  return (
+    <section className={style.all_movie_container }>
+    {allMovies.map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
+  </section>
+  )
+}
+
+
+async function RecoMovies() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/random`,
+      // random하게 movie를 보여 주도록 revalidate 설정
+      { next: {revalidate: 3}}
+  );
+  if(!res.ok) {
+      return <div>요청에 실패하였습니다</div>
+  }
+  const recoMovies: MovieData[] = await res.json();
+  return (
+    <section className={style.recom_movie_container }>
+      {recoMovies.slice(0, 3).map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
+    </section>
+  )
+
+}
+
+
 
 export default function Home() {
   return (
     <div className={style.container}>
     <h3>지금 가장 추천하는 영화</h3>
-    <section className={style.recom_movie_container }>
-      {movies.slice(0, 3).map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
-    </section>
+    <RecoMovies />
     <h3>등록된 모든 영화</h3>
-    <section className={style.all_movie_container }>
-      {movies.map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
-    </section>
+    <AllMovies />
+
   </div>
   );
 }

--- a/src/app/(searchable)/search/page.tsx
+++ b/src/app/(searchable)/search/page.tsx
@@ -2,6 +2,7 @@ import MovieItems from '@/components/movie-item';
 import movies from '@/mock/mock.json';
 import style from './page.module.css';
 
+
 export default function Page({searchParams}:
     {searchParams: {q?: string}}
 ) {

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,33 +1,33 @@
+import { MovieData } from "@/types";
 import style from "./page.module.css";
 
-const mockData = {
-    "id": 1022789,
-    "title": "인사이드 아웃 2",
-    "releaseDate": "2024-06-11",
-    "company": "Walt Disney Pictures, Pixar",
-    "genres": ["애니메이션", "가족", "모험", "코미디"],
-    "subTitle": "비상! 새로운 감정들이 몰려온다!",
-    "description": "13살이 된 라일리의 행복을 위해 매일 바쁘게 머릿속 감정 컨트롤 본부를 운영하는 ‘기쁨’, ‘슬픔’, ‘버럭’, ‘까칠’, ‘소심’. 그러던 어느 날, 낯선 감정인 ‘불안’, ‘당황’, ‘따분’, ‘부럽’이가 본부에 등장하고, 언제나 최악의 상황을 대비하며 제멋대로인 ‘불안’이와 기존 감정들은 계속 충돌한다. 결국 새로운 감정들에 의해 본부에서 쫓겨나게 된 기존 감정들은 다시 본부로 돌아가기 위해 위험천만한 모험을 시작하는데…",
-    "runtime": 97,
-    "posterImgUrl": "https://media.themoviedb.org/t/p/w300_and_h450_face/pmemGuhr450DK8GiTT44mgwWCP7.jpg"
-};
 
-export default function Page({
+export default async function Page({
   params,
 }: {
   params: { id: string | string[] };
 }) {
-  const {
-    id,
-    title,
-    releaseDate,
-    company,
-    genres,
-    subTitle,
-    description,
-    runtime,
-    posterImgUrl
-  } = mockData;
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/${params.id}`,
+    // 업데이트가 필요하지 않기 때문에 cache에 저장
+    { cache: "force-cache" }
+    );
+    if(!res.ok) {
+        return <div>요청에 실패하였습니다</div>
+    }
+    const detailMovies: MovieData = await res.json();
+
+    const {
+      id,
+      title,
+      releaseDate,
+      company,
+      genres,
+      subTitle,
+      description,
+      runtime,
+      posterImgUrl
+    } = detailMovies;
 
   return (
     <>


### PR DESCRIPTION
# 한입-씨네마 데이터 페칭 구현하기!

---

다음 요구사항을 참고해 `한입 씨네마` 프로젝트의 데이터 페칭 기능을 구현하고 각 페이지의 데이터 페칭 별로 적절한 `캐시 옵션을 설정`해주세요!

적어도 `인덱스`, `무비 페이지`의 데이터 페칭은 서버측에서 이루어져야 합니다.
서치 페이지의 데이터 페칭은 자유롭게 만들어주셔도 됩니다.
설정한 옵션별로 설명까지 달아주시면 제 의견도 달아드릴게요 😃

- **모든 영화 불러오기**

```jsx
async function AllMovies() {
  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`,
      // 업데이트가 필요하지 않기 때문에 cache에 저장
      { cache: "force-cache" }
  );
  if(!res.ok) {
      return <div>요청에 실패하였습니다</div>
  }
  const allMovies: MovieData[] = await res.json();
  return (
    <section className={style.all_movie_container }>
    {allMovies.map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
  </section>
  )
}
```

- **추천 영화 불러오기**

```jsx
async function RecoMovies() {
  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/random`,
      // random하게 movie를 보여 주도록 revalidate 설정
      { next: {revalidate: 3}}
  );
  if(!res.ok) {
      return <div>요청에 실패하였습니다</div>
  }
  const recoMovies: MovieData[] = await res.json();
  return (
    <section className={style.recom_movie_container }>
      {recoMovies.slice(0, 3).map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
    </section>
  )
}
```

- **movie/id 영화 불러오기**

```tsx
const res = await fetch(${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/${params.id},
// 업데이트가 필요하지 않기 때문에 cache에 저장
{ cache: "force-cache" }
);
```