### PR TITLE
FEAT: 풀 라우트 캐시 적용

### DIFF
--- a/src/app/(searchable)/layout.tsx
+++ b/src/app/(searchable)/layout.tsx
@@ -1,12 +1,14 @@
 import Searchbar from "@/components/searchbar";
-import { ReactNode } from "react";
+import { ReactNode, Suspense } from "react";
 
 export default function Home({ children }: {
     children: ReactNode
 }) {
   return (
     <div>
-      <Searchbar />
+      <Suspense fallback={<div>Loading...</div>}>
+        <Searchbar />
+      </Suspense>
       {children}
     </div>
   );

--- a/src/app/(searchable)/page.tsx
+++ b/src/app/(searchable)/page.tsx
@@ -35,7 +35,6 @@ async function RecoMovies() {
       {recoMovies.slice(0, 3).map((movie) => (<MovieItems key={movie.id} {...movie}/>))}
     </section>
   )
-
 }
 
 

--- a/src/app/(searchable)/search/page.tsx
+++ b/src/app/(searchable)/search/page.tsx
@@ -6,7 +6,7 @@ import style from './page.module.css';
 export default function Page({searchParams}:
     {searchParams: {q?: string}}
 ) {
-    const q = searchParams?.q
+    const q = searchParams?.q as string;
 
     return (
     <>

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,6 +1,14 @@
 import { MovieData } from "@/types";
 import style from "./page.module.css";
+import { notFound } from "next/navigation";
 
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`);
+  const allMovies: MovieData[] = await res.json();
+  return allMovies.map((movie) => ({id: movie.id.toString()}));
+}
 
 export default async function Page({
   params,
@@ -13,7 +21,7 @@ export default async function Page({
     { cache: "force-cache" }
     );
     if(!res.ok) {
-        return <div>요청에 실패하였습니다</div>
+       return <div>실패하였습니다</div>
     }
     const detailMovies: MovieData = await res.json();
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+    return <div>존재하지 않는 페이지입니다</div>
+}


### PR DESCRIPTION
# **한입-씨네마 풀라우트 캐시 적용하기**

---

1. **빌드 결과 화면 캡쳐**
- 풀 라우트 캐시가 잘 적용되었는지 확인하기 위해 빌드 결과를 꼭 찍어서 올려주세요!

![image](https://github.com/user-attachments/assets/2b54f1ed-6cdb-426f-9070-6a7204356a7a)

2. GitHub에 프로젝트 업로드 후 링크로 공유

> 주의. 빌드 중 useSearchParams를 사용하는 서치바 컴포넌트로 인해 오류가 발생할 수 있습니다. 이 경우 강의에서 안내드린대로 <Suspense> 컴포넌트를 사용해 해결해주세요
> 

```tsx
return (
    <div>
      <Suspense fallback={<div>Loading...</div>}>
        <Searchbar />
      </Suspense>
      {children}
    </div>
  );
```

1. 다음 요구사항을 참고해 "한입 씨네마" 프로젝트의 각 페이지에 **풀 라우트 캐시**를 적용해 주세요
- 서치 페이지를 제외한 모든 페이지를 **Static 페이지**로 설정해주세요
- 동적 경로를 갖는 무비 페이지는 아래의 조건도 함께 만족하도록 설정해주세요
    - 빌드 타임에 존재하는 모든 영화의 상세 페이지를 생성해야 합니다.
        
        ```tsx
        export async function generateStaticParams() {
          const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`);
          const allMovies: MovieData[] = await res.json();
          return allMovies.map((movie) => ({id: movie.id.toString()}));
        }
        ```
        
    
    - 빌드 타임에 생성하지 못한 페이지에 대해서는 404를 return 하도록 설정합니다.
        
        ```jsx
        export const dynamicParams = false;
        ```
        
![image](https://github.com/user-attachments/assets/1a04c1a4-26da-46a0-92c9-21d87b0e227d)